### PR TITLE
Fix Supabase request to avoid 406 error

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -12,6 +12,10 @@ export const supabase = createClient<Database>(
       autoRefreshToken: true,
       persistSession: true,
       detectSessionInUrl: true
+    },
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
     }
   }
 );


### PR DESCRIPTION
Add headers to the Supabase client configuration in `src/integrations/supabase/client.ts`.

* Add `Accept: application/json` header to the `createClient` options.
* Add `Content-Type: application/json` header to the `createClient` options.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sofer1445/shoping-list/pull/4?shareId=71f69433-1ead-47c6-a3de-26cf3dd4bfa3).