### PR TITLE
Fix infinite recursion in shopping_lists policy

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,6 @@
 project_id = "lpyxnwcxfpqiinncqswe"
+
+[policies]
+  [policies.shopping_lists]
+    check = "NEW.archived IS NOT TRUE"
+    using = "auth.uid() = created_by"


### PR DESCRIPTION
Update the policy for the `shopping_lists` relation to prevent infinite recursion.

* Add a new policy section for `shopping_lists` in `supabase/config.toml`
* Set the `check` condition to "NEW.archived IS NOT TRUE"
* Set the `using` condition to "auth.uid() = created_by"

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sofer1445/shoping-list/pull/8?shareId=45062276-e10b-424f-87b0-f7f7b74e35bb).